### PR TITLE
case 31230 - Handle CodeSignTool unzip not extracting into a folder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+- enter here
+
+## Related PRs
+
+- insert link here
+
+## Screenshots
+
+- insert here

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,8 +12,9 @@ apt-get -qq update
 echo "Installing JavaRuntime Environment"
 apt-get install -y -qq default-jre > /dev/null
 
+codeSignDir=$(ls | grep -w CodeSignTool-v*)
 
-if [ ! -d "CodeSignTool-v1.2.0" ]; then
+if [ -z "$codeSignDir" ] || [ ! -d ${codeSignDir} ]; then
 
     echo "-----INSTALLING CURL------"
     apt-get -y install curl
@@ -25,11 +26,24 @@ if [ ! -d "CodeSignTool-v1.2.0" ]; then
     curl https://www.ssl.com/download/29764/ --output CodeSignTool.zip
     echo "Extracting CodeSignTool"
     unzip -o CodeSignTool.zip
+    echo "Extracting Complete"
 
-    cd CodeSignTool-v1.2.0
+    codeSignDir=$(ls | grep -w CodeSignTool-v*)
+    echo "codeSignDirectory 1: ${codeSignDir}"
+
+    if [ -z "$codeSignDir" ] || [ ! -d ${codeSignDir} ]; then
+      echo "Unzipping to CodeSignTool-vFeenics"
+      unzip -o CodeSignTool.zip -d CodeSignTool-vFeenics
+    fi
+
+    codeSignDir=$(ls | grep -w CodeSignTool-v*)
+    echo "codeSignDirectory 2: ${codeSignDir}"
+
+    cd ${codeSignDir}
     mkdir -p "ssl-output"
 else
-    cd CodeSignTool-v1.2.0
+    codeSignDir=$(ls | grep -w CodeSignTool-v*)
+    cd ${codeSignDir}
 fi
 
 if [ ${istest} = true ] ; then


### PR DESCRIPTION
## Description

- https://feenics.fogbugz.com/f/cases/31230/CodeSign-Tool-failing-to-sign-files-in-github-workflow
- `keep-windows` was failing to sign files as part of the github workflow
- `unzip -o CodeSignTool.zip` use to extract into a folder called `CodeSignTool-v1.2.0`, it no longer seems to extract into any folder
- because we download this file, we're at the mercy of CodeSignTool people of how they package it

## Solution

- this should handle the case of the `unzip` not extracting into a folder, or extracting into any folder with the pattern of `CodeSignTool-v*`

## Related PRs

- https://github.com/feenicsinc/keep-windows/pull/817

## ToDo

- once merged, we need to create a v3 release and then update the use cases in the external workflow files (in other repos)